### PR TITLE
Add strum feature for iterating over languages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,12 +60,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "iso639-1"
 version = "0.3.0"
 dependencies = [
  "failure",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
@@ -127,6 +135,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +175,25 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "strum"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "rustversion",
+ "syn 1.0.92",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ See full [README.md](./iso639-1/README.md)
 Optional features:
 
 - [`serde`](https://github.com/serde-rs/serde): Enable serialization/deserialization via serde.
+- `strum`: Derive [EnumIter](https://docs.rs/strum_macros/0.24.0/strum_macros/derive.EnumIter.html) on Iso639_1.
 
 ## Iso639-2
 

--- a/iso639-1/Cargo.toml
+++ b/iso639-1/Cargo.toml
@@ -13,11 +13,18 @@ readme = "README.md"
 workspace = ".."
 
 # --------------------------------------------------------------------
+[features]
+# --------------------------------------------------------------------
+strum = ["dep:strum", "dep:strum_macros"]
+
+# --------------------------------------------------------------------
 [dependencies]
 # --------------------------------------------------------------------
 failure = "0.1.3"
 
 serde = { version = "1", optional = true }
+strum = { version = "0.24", optional = true }
+strum_macros = { version = "0.24", optional = true }
 
 # --------------------------------------------------------------------
 [dev-dependencies]
@@ -41,3 +48,8 @@ path = "tests/0003_to_code.rs"
 name = "serde"
 path = "tests/0004_serde.rs"
 required-features = ["serde"]
+
+[[test]]
+name = "strum"
+path = "tests/0005_strum.rs"
+required-features = ["strum"]

--- a/iso639-1/src/lib.rs
+++ b/iso639-1/src/lib.rs
@@ -43,6 +43,9 @@
 #[cfg(feature = "serde")]
 extern crate serde;
 
+#[cfg(feature = "strum")]
+extern crate strum_macros;
+
 #[cfg(feature = "serde")]
 mod serde_impl;
 
@@ -121,6 +124,7 @@ impl From<Iso639v1ErrorKind> for Iso639v1Error {
 /// }
 /// ```
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "strum", derive(strum_macros::EnumIter))]
 pub enum Iso639_1 {
     /// 639-2: aar, name: Afar (Afaraf)
     Aa,

--- a/iso639-1/src/lib.rs
+++ b/iso639-1/src/lib.rs
@@ -17,6 +17,7 @@
 //! Optional features:
 //!
 //! - [`serde`][]: Enable serialization/deserialization via serde.
+//! - [`strum`][]: Derive [EnumIter](https://docs.rs/strum_macros/0.24.0/strum_macros/derive.EnumIter.html) on Iso639_1.
 //!
 //! ## Example
 //!

--- a/iso639-1/tests/0005_strum.rs
+++ b/iso639-1/tests/0005_strum.rs
@@ -1,0 +1,12 @@
+extern crate iso639_1;
+
+use iso639_1::Iso639_1;
+
+#[test]
+fn strum_iter() {
+    let mut iter = Iso639_1::iter();
+    assert_eq!(Some(Iso639_1::Aa), iter.next());
+    assert_eq!(Some(Iso639_1::Ab), iter.next());
+    assert_eq!(Some(Iso639_1::Af), iter.next());
+    assert_eq!(Some(Iso639_1::Ak), iter.next());
+}


### PR DESCRIPTION
For our use case it was necessary to get a list of all possible languages, so i added this functionality with a new, optional feature `strum_macros`. I only added this for iso639-1, because thats the crate we use.

Let me know if i should change anything in order to get this merged.